### PR TITLE
refactor: disable updating menus logic in sync_menus controller

### DIFF
--- a/modules/custom_module/controllers/menu_sync_controller.py
+++ b/modules/custom_module/controllers/menu_sync_controller.py
@@ -118,8 +118,8 @@ class MenuSyncController(http.Controller):
         for menu_data in created_menus:
             self._create_menu(menu_data, pos_menus_model, product_category_model, pos_category_model, account_tax, s3_base_url)
 
-        for menu_data in updated_menus:
-            self._update_menu(menu_data, pos_menus_model, product_category_model, pos_category_model, account_tax, s3_base_url)
+        # for menu_data in updated_menus:
+        #    self._update_menu(menu_data, pos_menus_model, product_category_model, pos_category_model, account_tax, s3_base_url)
 
         for menu_id in deleted_menus:
             self._deactivate_menu(menu_id, pos_menus_model)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
